### PR TITLE
agents-workshop: fix agent_setup failing on deprecated claude-3-7-sonnet PPT

### DIFF
--- a/agents-workshop/agent_setup/agent.py
+++ b/agents-workshop/agent_setup/agent.py
@@ -33,7 +33,8 @@ set_uc_function_client(client)
 # Define your LLM endpoint and system prompt
 ############################################
 #LLM_ENDPOINT_NAME = "databricks-meta-llama-3-3-70b-instruct"
-LLM_ENDPOINT_NAME = "databricks-claude-3-7-sonnet"
+#LLM_ENDPOINT_NAME = "databricks-claude-sonnet-4-6"
+LLM_ENDPOINT_NAME = "databricks-gpt-oss-120b"
 llm = ChatDatabricks(endpoint=LLM_ENDPOINT_NAME)
 
 system_prompt = "You are a customer success specialist that helps users with product questions as part of a Databricks lab. Use tools to retrieve all information needed and help customers fully understand the products they're asking about. Aim to provide value in every interaction."


### PR DESCRIPTION
## Summary
- `databricks-claude-3-7-sonnet` was removed from pay-per-token serving, causing the `agents-workshop/agent_setup/agent.py` notebook to fail at deploy time with:
  ```
  NotFoundError: 404 - {'error_code': 'NOT_FOUND', 'message': 'Pay-per-token for this model is disabled. Please see Databricks documentation for supported Foundation Models.'}
  ```
- Swapped the active `LLM_ENDPOINT_NAME` to `databricks-gpt-oss-120b` — the same model used in Part 2 (`02_agent_eval/agent.py`), so the full workshop now runs on a single consistent model.
- Left `databricks-claude-sonnet-4-6` commented out as a quick Claude fallback alongside the existing `databricks-meta-llama-3-3-70b-instruct` fallback.

## Why gpt-oss-120b
- Confirmed live on PPT in `e2-demo-field-eng` (and across the FE workspaces lab attendees use).
- Matches the model already shipping in `02_agent_eval/agent.py` — students see one model end-to-end.
- Supports tool calling, which the LangGraph `bind_tools(tools)` path requires.

## Test plan
- [ ] Run `agents-workshop/agent_setup/agent_setup.py` end-to-end and confirm `mlflow.pyfunc.log_model(...)` succeeds.
- [ ] Confirm `agents.deploy(...)` produces a working `agents_agents_lab-product-product_agent` endpoint.
- [ ] Sanity-query the deployed endpoint with the existing input example ("What color options are available for the Aria Modern Bookshelf?") and confirm it tool-calls into the vector search retriever.

This pull request and its description were written by Isaac.